### PR TITLE
	当动态添加thrift服务器失败时 添加错误原因日志输出

### DIFF
--- a/src/main/java/com/wmz7year/thrift/pool/ThriftConnectionPool.java
+++ b/src/main/java/com/wmz7year/thrift/pool/ThriftConnectionPool.java
@@ -213,6 +213,8 @@ public class ThriftConnectionPool<T extends TServiceClient> implements Serializa
 				ThriftConnection<T> connection = obtainRawInternalConnection(thriftServerInfo);
 				connection.close();
 			} catch (Exception e) {
+				logger.error("无法添加Thrfit服务器到连接池 ip:" + thriftServerInfo.getHost() + " 端口：" + thriftServerInfo.getPort(),
+						e);
 				return false;
 			}
 			ThriftConnectionPartition<T> thriftConnectionPartition = createThriftConnectionPartition(thriftServerInfo);


### PR DESCRIPTION
避免了添加服务器失败不知道原因的问题
