### PR TITLE
Multiple code improvements - squid:S1213, squid:S1488

### DIFF
--- a/src/main/java/com/wmz7year/thrift/pool/TaskEngine.java
+++ b/src/main/java/com/wmz7year/thrift/pool/TaskEngine.java
@@ -33,18 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TaskEngine {
 	private static TaskEngine instance = null;
 
-	/**
-	 * Returns a task engine instance (singleton).
-	 *
-	 * @return a task engine.
-	 */
-	public static synchronized TaskEngine getInstance() {
-		if (instance == null) {
-			instance = new TaskEngine();
-		}
-		return instance;
-	}
-
 	private Timer timer;
 	private ExecutorService executor;
 	private Map<TimerTask, TimerTaskWrapper> wrappedTasks = new ConcurrentHashMap<TimerTask, TimerTaskWrapper>();
@@ -68,6 +56,18 @@ public class TaskEngine {
 				return thread;
 			}
 		});
+	}
+
+	/**
+	 * Returns a task engine instance (singleton).
+	 *
+	 * @return a task engine.
+	 */
+	public static synchronized TaskEngine getInstance() {
+		if (instance == null) {
+			instance = new TaskEngine();
+		}
+		return instance;
 	}
 
 	/**

--- a/src/main/java/com/wmz7year/thrift/pool/ThriftConnectionPartition.java
+++ b/src/main/java/com/wmz7year/thrift/pool/ThriftConnectionPartition.java
@@ -244,13 +244,11 @@ public class ThriftConnectionPartition<T extends TServiceClient> implements Seri
 	 * @return 连接代理对象
 	 */
 	protected ThriftConnectionHandle<T> poolFreeConnection() {
-		ThriftConnectionHandle<T> result = this.freeConnections.poll();
-		return result;
+		return this.freeConnections.poll();
 	}
 
 	public ThriftConnection<T> poolFreeConnection(long timeout, TimeUnit unit) throws InterruptedException {
-		ThriftConnection<T> result = this.freeConnections.poll(timeout, unit);
-		return result;
+		return this.freeConnections.poll(timeout, unit);
 	}
 
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - Statements should be on separate lines.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava
